### PR TITLE
Replace number/employee_details with num1/staff_details

### DIFF
--- a/file1.py
+++ b/file1.py
@@ -3,14 +3,14 @@ val1 = True
 print(val1)
 
 # Number to Boolean
-number = 10
-print(bool(number))
+num1 = 10
+print(bool(num1))
 
-number = -5
-print(bool(number))
+num1 = -5
+print(bool(num1))
 
-number = 0
-print(bool(number))
+num1 = 0
+print(bool(num1))
 
 # Boolean from comparison operator
 val1 = 6

--- a/file2.py
+++ b/file2.py
@@ -1,8 +1,8 @@
 # Assign a numeric value
-number = 70
+num1 = 70
 
 # Check the is more than 70 or not
-if (number >= 70):
+if (num1 >= 70):
     print("You have passed")
 else:
     print("You have not passed")

--- a/file3.py
+++ b/file3.py
@@ -1,5 +1,5 @@
 # Switcher for implementing switch case options
-def employee_details(ID):
+def staff_details(ID):
     switcher = {
         "1004": "Employee Name: MD. Mehrab",
         "1009": "Employee Name: Mita Rahman",  
@@ -12,4 +12,4 @@ def employee_details(ID):
 # Take the employee ID
 ID = input("Enter the employee ID: ")
 # Print the output
-print(employee_details(ID))
+print(staff_details(ID))


### PR DESCRIPTION
This replaces the terms number/employee_details in Python files with num1/staff_details

[_Created by Sourcegraph batch change `michael/number-employee_details-wording`._](https://cse-k8s.sgdev.org/users/michael/batch-changes/number-employee_details-wording)